### PR TITLE
Refactor code in routes to follow 'resources' format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get "/", to: "welcome#index"
-
-  get "/merchants", to: "merchants#index"
-  get "/merchants/new", to: "merchants#new"
-  get "/merchants/:id", to: "merchants#show"
+  resources :merchants, only: [:index, :new, :show]
+  # get "/merchants", to: "merchants#index"
+  # get "/merchants/new", to: "merchants#new"
+  # get "/merchants/:id", to: "merchants#show"
   post "/merchants", to: "merchants#create"
   get "/merchants/:id/edit", to: "merchants#edit"
   patch "/merchants/:id", to: "merchants#update"
   delete "/merchants/:id", to: "merchants#destroy"
 
-  get "/items", to: "items#index"
-  get "/items/:id", to: "items#show"
+
+  resources :items, only: [:index, :show]
+  # get "/items", to: "items#index"
+  # get "/items/:id", to: "items#show"
   get "/items/:id/edit", to: "items#edit"
   patch "/items/:id", to: "items#update"
   get "/merchants/:merchant_id/items", to: "items#index"


### PR DESCRIPTION
After we merge this, we will all see some merge conflicts with the routes when we pull from development. Be sure to pick the ones with the 'resources' in it. And if anyone has any doubts, I've left the original routes there, just commented them out.